### PR TITLE
Fix compilation in GHC >= 8.8

### DIFF
--- a/bitcoin-script.cabal
+++ b/bitcoin-script.cabal
@@ -16,12 +16,13 @@ description:
    decompiling of the script assembly, and continuously merges changes downstream.
 
    The advantage this library has over Haskoin is that it uses very few
-   dependencies and doesn't rely on external libraries such as LevelDB and snappy.            
-                      
+   dependencies and doesn't rely on external libraries such as LevelDB and snappy.
+
 build-type: Simple
 data-files: LICENSE, README.md
 cabal-version: >= 1.10
-tested-with: GHC == 7.6, GHC == 7.8, GHC == 7.10
+tested-with: GHC == 7.6, GHC == 7.8, GHC == 7.10, GHC == 8.6, GHC == 8.8
+             GHC == 8.10, GHCJS == 8.6
 
 library
   hs-source-dirs:      src
@@ -30,8 +31,8 @@ library
 
   exposed-modules:     Data.Bitcoin.Script
 
-  other-modules:       Data.Bitcoin.Script.Types 
-  
+  other-modules:       Data.Bitcoin.Script.Types
+
   build-depends:       base                     >= 4.3          && < 5
                      , text
                      , bytestring

--- a/bitcoin-script.cabal
+++ b/bitcoin-script.cabal
@@ -1,6 +1,6 @@
 name: bitcoin-script
 category: Network, Finance
-version: 0.11.1
+version: 0.11.2
 license: MIT
 license-file: LICENSE
 copyright: (c) 2015 Leon Mergen

--- a/bitcoin-script.nix
+++ b/bitcoin-script.nix
@@ -3,7 +3,7 @@
 }:
 mkDerivation {
   pname = "bitcoin-script";
-  version = "0.11.1";
+  version = "0.11.2";
   src = ./.;
   buildDepends = [ base base16-bytestring binary bytestring text ];
   testDepends = [ base bytestring hspec ];

--- a/default.nix
+++ b/default.nix
@@ -1,2 +1,2 @@
-{ nixpkgs ? import <nixpkgs> {}, compiler ? "ghc7101" }:
-nixpkgs.haskellPackages.callPackage ./bitcoin-script.nix { }
+{ pkgs ? import (import ./nixpkgs.nix) { }, compiler ? "ghc865" }:
+pkgs.haskell.packages.${compiler}.callPackage ./bitcoin-script.nix { }

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,0 +1,4 @@
+builtins.fetchTarball {
+  url = "https://github.com/NixOS/nixpkgs-channels/archive/b0e3df2f8437767667bd041bb336e9d62a97ee81.tar.gz";
+  sha256 = "0d34k96l0gzsdpv14vnxdfslgk66gb0nsjz7qcqz1ykb0i7n3n07";
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,2 +1,2 @@
-{ nixpkgs ? import <nixpkgs> {}, compiler ? "ghc7101" }:
-(import ./default.nix { inherit nixpkgs compiler; }).env
+{ pkgs ? import (import ./nixpkgs.nix) { }, compiler ? "ghc865" }:
+(import ./default.nix { inherit pkgs compiler; }).env

--- a/src/Data/Bitcoin/Script/Types.hs
+++ b/src/Data/Bitcoin/Script/Types.hs
@@ -340,21 +340,21 @@ instance Binary ScriptOp where
             let len = BS.length payload
             case optype of
                 OPCODE -> do
-                    unless (len <= 0x4b) $ fail
+                    unless (len <= 0x4b) $ error
                         "OP_PUSHDATA OPCODE: Payload size too big"
                     putWord8 $ fromIntegral len
                 OPDATA1 -> do
-                    unless (len <= 0xff) $ fail
+                    unless (len <= 0xff) $ error
                         "OP_PUSHDATA OPDATA1: Payload size too big"
                     putWord8 0x4c
                     putWord8 $ fromIntegral len
                 OPDATA2 -> do
-                    unless (len <= 0xffff) $ fail
+                    unless (len <= 0xffff) $ error
                         "OP_PUSHDATA OPDATA2: Payload size too big"
                     putWord8 0x4d
                     putWord16le $ fromIntegral len
                 OPDATA4 -> do
-                    unless (len <= 0x7fffffff) $ fail
+                    unless (len <= 0x7fffffff) $ error
                         "OP_PUSHDATA OPDATA4: Payload size too big"
                     putWord8 0x4e
                     putWord32le $ fromIntegral len


### PR DESCRIPTION
Replace uses of `fail` in `pinary`'s `Put` monad with `error`. `Put` doesn't implement `fail` anymore in newer GHCs, and `fail` was `error` before anyway.

To make your job easier, I went ahead and pinned a newer default `nixpkgs` version and bumped the library version to `0.11.2`. 

I built and ran the tests with GHC 8.6.5, GHC 8.8.3, GHC 8.10.1 and GHCJS 8.6.

Thanks!